### PR TITLE
FIX: Property "float" must be followed by a ':'

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -104,7 +104,7 @@ button.delete {
 .main {
     width: 80%;
     height: calc(100% - 37px);
-    float left;
+    float: left;
     overflow:scroll;
     padding: 20px;
     box-sizing: border-box;


### PR DESCRIPTION
I'm following your course and using SASS stylesheets and `webpack-dev-server` for my live reloading needs. The module build fails with the `:` missing. 

```
Module build failed: 
    float left;
   ^
      Property "float" must be followed by a ':'
      in /Sandbox/flashcard-app/src/styles.scss (line 107, column 5)
```
